### PR TITLE
redesigned logger format

### DIFF
--- a/git_system_follower/logger.py
+++ b/git_system_follower/logger.py
@@ -17,9 +17,11 @@ import logging
 from colorama import init
 
 from git_system_follower.variables import ROOT_DIR
-from git_system_follower.utils.logger import SUCCESS_LEVEL_NUM, SUCCESS_LEVEL_NAME
-from git_system_follower.utils.logger import (get_stream_handler, get_file_handler, success,
-                                              disable_info_for_other_loggers)
+from git_system_follower.utils.logger import (
+    SUCCESS_LEVEL_NUM, SUCCESS_LEVEL_NAME,
+    get_stream_handler, get_file_handler, success, disable_info_for_other_loggers,
+    ColoredFormatter, SHORT_DEBUG_FORMAT, SHORT_DEBUG_DATE_FORMAT, SHORT_FORMAT, SHORT_DATE_FORMAT
+)
 
 
 __all__ = ['LOG_FILE_PATH', 'logger', 'set_level']
@@ -52,5 +54,9 @@ logger = _get_logger('root')
 
 
 def set_level(is_debug: bool) -> None:
-    level = logging.DEBUG if is_debug else logging.INFO
+    level, fmt, datefmt = logging.INFO, SHORT_FORMAT, SHORT_DATE_FORMAT
+    if is_debug:
+        level, fmt, datefmt = logging.DEBUG, SHORT_DEBUG_FORMAT, SHORT_DEBUG_DATE_FORMAT
+
     logger.handlers[0].setLevel(level=level)  # set level only for stream handler
+    logger.handlers[0].setFormatter(ColoredFormatter(fmt=fmt, datefmt=datefmt))

--- a/git_system_follower/utils/logger.py
+++ b/git_system_follower/utils/logger.py
@@ -19,13 +19,21 @@ import click
 from colorama import Fore, Style
 
 
+# for banner + print_params
+NO_FORMAT = '%(message)s'
+NO_DATE_FORMAT = ''
+
 # for stdout
-_SHORT_FORMAT = '[%(asctime)s.%(msecs)03d] %(levelname)-18s | %(message)s'
-_SHORT_DATE_FORMAT = '%H:%M:%S'
+SHORT_FORMAT = f'{Fore.CYAN}%(asctime)s.%(msecs)03d{Fore.RESET} %(message)s'
+SHORT_DATE_FORMAT = '%M:%S'
+
+# for debug stdout
+SHORT_DEBUG_FORMAT = f'{Fore.CYAN}%(asctime)s.%(msecs)03d{Fore.RESET} %(levelname)-18s | %(message)s'
+SHORT_DEBUG_DATE_FORMAT = '%M:%S'
 
 # for log file
-_FORMAT = '[%(asctime)s.%(msecs)03d] %(levelname)-8s | %(filename)s:%(funcName)s:%(lineno)d - %(message)s'
-_DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
+FORMAT = '[%(asctime)s.%(msecs)03d] %(levelname)-8s | %(filename)s:%(funcName)s:%(lineno)d - %(message)s'
+DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 
 # New logging level
 SUCCESS_LEVEL_NUM = 25
@@ -61,7 +69,7 @@ class RemoveColorFilter(logging.Filter):
         return True
 
 
-file_formatter = logging.Formatter(fmt=_FORMAT, datefmt=_DATE_FORMAT)
+file_formatter = logging.Formatter(fmt=FORMAT, datefmt=DATE_FORMAT)
 
 
 def disable_info_for_other_loggers(names: list[str]) -> None:
@@ -73,7 +81,7 @@ def disable_info_for_other_loggers(names: list[str]) -> None:
 def get_stream_handler() -> logging.StreamHandler:
     handler = logging.StreamHandler()
     handler.setLevel(level=logging.INFO)
-    handler.setFormatter(ColoredFormatter(fmt=_SHORT_FORMAT, datefmt=_SHORT_DATE_FORMAT))
+    handler.setFormatter(ColoredFormatter(fmt=NO_FORMAT, datefmt=NO_DATE_FORMAT))
     return handler
 
 


### PR DESCRIPTION
All current formats:
1.  `no format` for stdin to print banner + params: `message`
2.  `short format` for stdin in INFO mode: `HH:MM:SS.sss message` (colored)
3.  `short debug format` for stdin in DEBUG mode: `HH:MM:SS.sss level | message` (colored)
4.  `format` for `.log` file: `[HH:MM:SS.sss] level | module:function:line - message` (no colored)